### PR TITLE
Use file moves instead of copy & cleanup tmp dir

### DIFF
--- a/updater/file.go
+++ b/updater/file.go
@@ -40,7 +40,7 @@ func SHA1Hash(filePath string) ([]byte, error) {
 
 // CreateTempDir returns a temporary directory name and error if the creation failed
 func CreateTempDir() (tempDir string, err error) {
-	tempDir, err = ioutil.TempDir("", "updater")
+	tempDir, err = ioutil.TempDir(GetExeDir(), "updater")
 	if nil != err {
 		return "", err
 	}

--- a/updater/file.go
+++ b/updater/file.go
@@ -38,9 +38,13 @@ func SHA1Hash(filePath string) ([]byte, error) {
 	return hash.Sum(nil), nil
 }
 
+func TempDirPrefix() string {
+	return "hupdate_tmp_"
+}
+
 // CreateTempDir returns a temporary directory name and error if the creation failed
 func CreateTempDir() (tempDir string, err error) {
-	tempDir, err = ioutil.TempDir(GetExeDir(), "updater")
+	tempDir, err = ioutil.TempDir(GetExeDir(), TempDirPrefix())
 	if nil != err {
 		return "", err
 	}

--- a/updater/handler.go
+++ b/updater/handler.go
@@ -3,8 +3,10 @@ package updater
 import (
 	"crypto/rsa"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 )
 
 // Infoer interface used to make testing easier
@@ -29,6 +31,14 @@ func Handler() int {
 	}
 
 	info := Info{}
+
+	// cleanup any old tmp directories on every run
+	items, _ := ioutil.ReadDir(GetExeDir())
+	for _, item := range items {
+		if item.IsDir() && strings.HasPrefix(item.Name(), TempDirPrefix()) {
+			DeleteDirectory(item.Name())
+		}
+	}
 
 	// check for updates
 	if args.Quickcheck && args.Justcheck {

--- a/updater/handler.go
+++ b/updater/handler.go
@@ -90,7 +90,7 @@ func UpdateHandler(infoer Infoer, args Args) (int, error) {
 		err = fmt.Errorf("no temp dir; %v", err)
 		return EXIT_ERROR, err
 	}
-	defer os.RemoveAll(tmpDir)
+	defer DeleteDirectory(tmpDir)
 
 	// parse the WYC file for get update site, installed version, etc.
 	iuc, err := infoer.ParseWYC(args.Cdata)
@@ -178,10 +178,12 @@ func UpdateHandler(infoer Infoer, args Args) (int, error) {
 
 	// backup the existing files that will be overwritten by the update
 	backupDir, err := BackupFiles(updates, instDir)
+	defer DeleteDirectory(backupDir)
 	if nil != err {
+		// Errors from rollback may occur from missing expected files - ignore
+		RollbackFiles(backupDir, instDir)
 		return EXIT_ERROR, err
 	}
-	defer DeleteDirectory(backupDir)
 
 	// TODO is there a way to clean this up
 	err = InstallUpdate(udt, updates, instDir)

--- a/updater/handler.go
+++ b/updater/handler.go
@@ -181,6 +181,7 @@ func UpdateHandler(infoer Infoer, args Args) (int, error) {
 	if nil != err {
 		return EXIT_ERROR, err
 	}
+	defer DeleteDirectory(backupDir)
 
 	// TODO is there a way to clean this up
 	err = InstallUpdate(udt, updates, instDir)


### PR DESCRIPTION
This will defer the service restart until the update has already succeeded. If the update fails, delete the temp directory after moving everything back.

Current behavior:
![Current](https://user-images.githubusercontent.com/85883564/158630992-7253260c-4343-40ea-acf1-c5a6409cb171.png)

New behavior:
![Proposed](https://user-images.githubusercontent.com/85883564/158631048-f176b4d3-2c26-437e-8d9a-68bdf5c78b7b.png)

